### PR TITLE
Reduce the detector element name size

### DIFF
--- a/src/detect.js
+++ b/src/detect.js
@@ -6,7 +6,7 @@
 export default function detect() {
   try {
     customElements.define(
-      'corpuscule-custom-builtin-elements-detector',
+      'corpuscule-cbe-detector',
       document.createElement('p').constructor,
       {extends: 'p'},
     );


### PR DESCRIPTION
This PR reduces the name size of the detector element that allows to make the code size a bit smaller.