### PR TITLE
Fix several mistakes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,12 @@
 {
+  "plugins": [
+    [
+      "@babel/plugin-proposal-class-properties",
+      {
+        "loose": true
+      }
+    ]
+  ],
   "presets": [
     [
       "@babel/preset-env",

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -44,6 +44,7 @@ describe('custom-builtin-elements-polyfill', () => {
       const foo = document.createElement('a', {is: name});
       expect(foo instanceof Foo).toBeTruthy();
       expect(foo instanceof HTMLAnchorElement).toBeTruthy();
+      expect(foo.nodeName).toBe('A');
     });
 
     it('applies user-defined constructor and prototype to a created element', () => {

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -203,21 +203,32 @@ describe('custom-builtin-elements-polyfill', () => {
     });
 
     describe('whenDefined', () => {
-      it('waits until the component is defined', done => {
+      it('runs properly if the component declared before the waiting starts', done => {
         class Foo extends HTMLButtonElement {}
         const name = defineCBE(Foo, 'button');
 
         customElements.whenDefined(name).then(done);
       });
 
-      it('uses the native method if the element is not recognized', () => {
-        if (hasNativeCustomElementRegistry) {
-          pending();
-        }
+      it('waits properly when component declared after the waiting starts', done => {
+        const name = generateName();
 
-        expect(() => customElements.whenDefined('x-foo')).toThrowError(
-          'Not supported',
-        );
+        class Foo extends HTMLButtonElement {}
+        customElements.whenDefined(name).then(done);
+
+        setTimeout(() => defineCBE(Foo, 'button', name), 200);
+      });
+
+      it('waits properly if multiple listeners are added', done => {
+        const name = generateName();
+
+        class Foo extends HTMLButtonElement {}
+        const firstListener = customElements.whenDefined(name);
+        const secondListener = customElements.whenDefined(name);
+
+        Promise.all([firstListener, secondListener]).then(done);
+
+        setTimeout(() => defineCBE(Foo, 'button', name), 200);
       });
     });
   });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -93,6 +93,7 @@ module.exports = config => {
           include: ['node_modules/@open-wc/**', '__tests__/**'],
           ...babelrc,
           plugins: [
+            ...babelrc.plugins,
             '@babel/plugin-transform-instanceof',
             'babel-plugin-transform-async-to-promises',
           ],
@@ -113,7 +114,10 @@ module.exports = config => {
             require('rollup-plugin-babel')({
               babelrc: false,
               ...babelrc,
-              plugins: coverage ? ['babel-plugin-istanbul'] : [],
+              plugins: [
+                ...babelrc.plugins,
+                coverage && 'babel-plugin-istanbul',
+              ].filter(Boolean),
             }),
           ],
           treeshake: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -276,6 +276,73 @@
         }
       }
     },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.6.0.tgz",
+      "integrity": "sha512-O1QWBko4fzGju6VoVvrZg0RROCVifcLxiApnGP3OWfWzvxRZFCoBD81K5ur5e3bVY2Vf/5rIJm8cqPKn8HUJng==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-member-expression-to-functions": "^7.5.5",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.5.5",
+        "@babel/helper-split-export-declaration": "^7.4.4"
+      },
+      "dependencies": {
+        "@babel/helper-function-name": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.0.0",
+            "@babel/template": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+          "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/template": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+          "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.6.0",
+            "@babel/types": "^7.6.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
     "@babel/helper-define-map": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
@@ -1043,6 +1110,16 @@
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-remap-async-to-generator": "^7.1.0",
         "@babel/plugin-syntax-async-generators": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.5.5.tgz",
+      "integrity": "sha512-AF79FsnWFxjlaosgdi421vmYG6/jg79bVD0dpD44QdgobzHKuLZ6S3vl8la9qIeSwGi8i1fS0O1mfuDAAdo1/A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.5.5",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-proposal-dynamic-import": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "homepage": "https://github.com/corpusculejs/custom-builtin-elements#readme",
   "devDependencies": {
     "@babel/core": "^7.6.0",
+    "@babel/plugin-proposal-class-properties": "^7.5.5",
     "@babel/plugin-transform-instanceof": "^7.5.5",
     "@babel/preset-env": "^7.6.0",
     "@open-wc/testing-helpers": "^1.2.1",

--- a/src/CustomBuiltInElementsRegistry.js
+++ b/src/CustomBuiltInElementsRegistry.js
@@ -1,0 +1,79 @@
+/**
+ * Customized built-in elements registry. Contains both "name => constructor"
+ * and "constructor => name" associations.
+ */
+export class CustomBuiltInElementsRegistry {
+  listeners = {};
+  registry = {};
+  reversed = new WeakMap();
+
+  /**
+   * Gets the constructor if the name received or the name if constructor
+   * received, respectively.
+   *
+   * @param {string|Function} nameOrConstructor a name or a constructor
+   *
+   * @returns {Function|string} a constructor or a name depending on the
+   * `nameOrConstructor` value type.
+   */
+  get(nameOrConstructor) {
+    return typeof nameOrConstructor === 'string'
+      ? this.registry[nameOrConstructor]
+      : this.reversed.get(nameOrConstructor);
+  }
+
+  /**
+   * Checks the existence of the name/constructor in the registry.
+   *
+   * @param {string|Function} nameOrConstructor a name or a constructor of
+   * customized built-in element to check.
+   *
+   * @returns {boolean} a result of the check.
+   */
+  has(nameOrConstructor) {
+    return typeof nameOrConstructor === 'string'
+      ? !!this.registry[nameOrConstructor]
+      : this.reversed.has(nameOrConstructor);
+  }
+
+  /**
+   * Associates a name of the customized built-in element with its constructor.
+   *
+   * @param {string} name a new name of the customized built-in element.
+   * @param {Function} constructor a constructor of the customized built-in
+   * element.
+   */
+  set(name, constructor) {
+    const {listeners, registry, reversed} = this;
+
+    registry[name] = constructor;
+    reversed.set(constructor, name);
+
+    if (listeners[name]) {
+      listeners[name].forEach(listener => listener());
+      listeners[name] = null;
+    }
+  }
+
+  /**
+   * Gets a promise that resolves when the customized built-in element with the
+   * provided name is defined.
+   *
+   * @param {string} name a name of customized built-in element to be defined.
+   * @returns {Promise<undefined>} a promise that resolves when the element is
+   * defined.
+   */
+  whenDefined(name) {
+    return new Promise(resolve => {
+      const {listeners, registry} = this;
+
+      if (registry[name]) {
+        resolve();
+      } else if (listeners[name]) {
+        listeners[name].push(resolve);
+      } else {
+        listeners[name] = [resolve];
+      }
+    });
+  }
+}

--- a/src/customElementsBase.js
+++ b/src/customElementsBase.js
@@ -7,6 +7,7 @@ if (!('customElements' in window)) {
     define: mock,
     get: mock,
     upgrade: mock,
-    whenDefined: mock,
+    // Promise that never resolves and then never wins the Promise.race.
+    whenDefined: () => new Promise(() => {}),
   };
 }

--- a/src/patchCustomElementRegistry.js
+++ b/src/patchCustomElementRegistry.js
@@ -2,6 +2,7 @@ import {
   elementsRegistry,
   nativeConstructorRegistry,
   patchedPrototypesRegistry,
+  tagsRegistry,
 } from './shared';
 import {
   connect,
@@ -63,6 +64,7 @@ function patchCustomElementRegistry() {
         }
 
         elementsRegistry.set(name, constructor);
+        tagsRegistry.set(constructor, options.extends);
 
         const pattern = new RegExp(options.extends, 'i');
 

--- a/src/patchNativeConstructors.js
+++ b/src/patchNativeConstructors.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-prototype-builtins */
 import {
   $attributeChangedCallback,
-  elementsReversedRegistry,
+  elementsRegistry,
   nativeConstructorNames,
   nativeConstructorRegistry,
   tagsRegistry,
@@ -32,7 +32,7 @@ function patchNativeConstructors() {
       constructor() {
         const {constructor} = this;
 
-        if (!elementsReversedRegistry.has(constructor)) {
+        if (!elementsRegistry.has(constructor)) {
           throw new TypeError('Illegal constructor');
         }
 

--- a/src/patchNativeMethods.js
+++ b/src/patchNativeMethods.js
@@ -51,8 +51,8 @@ function patchInnerHTML(proto) {
 function patchNativeMethods() {
   const {createElement} = document;
   document.createElement = function(_, options) {
-    if (options && options.is && elementsRegistry[options.is]) {
-      return new elementsRegistry[options.is]();
+    if (options && options.is && elementsRegistry.has(options.is)) {
+      return new (elementsRegistry.get(options.is))();
     }
 
     return createElement.apply(document, arguments);

--- a/src/shared.js
+++ b/src/shared.js
@@ -1,22 +1,14 @@
+import {CustomBuiltInElementsRegistry} from './CustomBuiltInElementsRegistry';
+
 export const supportsNativeWebComponents =
   'ShadowRoot' in window &&
   !('ShadyCSS' in window && !window.ShadyCSS.nativeShadow);
 
 /**
- * Customized built-in elements registry. Contains "name => constructor"
- * associations.
- *
- * @type {Record<string, object>}
+ * Customized built-in elements registry.
+ * @see {CustomBuiltInElementsRegistry}
  */
-export const elementsRegistry = {};
-
-/**
- * A registry that contains the "constructor => name" associations for
- * customized built-in elements.
- *
- * @type {WeakMap<object, string>}
- */
-export const elementsReversedRegistry = new WeakMap();
+export const elementsRegistry = new CustomBuiltInElementsRegistry();
 
 /**
  * A registry that associates the user constructor with the specific tag. It is

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,6 @@ import {
   $connectedCallback,
   $disconnectedCallback,
   elementsRegistry,
-  elementsReversedRegistry,
   lifecycleRegistry,
   supportsNativeWebComponents,
   upgradingRegistry,
@@ -81,11 +80,11 @@ export function runForDescendants(root, check, callback, pierce = false) {
 export function recognizeElementByIsAttribute(element) {
   const name = element.getAttribute('is');
 
-  return name && elementsRegistry[name];
+  return name && elementsRegistry.get(name);
 }
 
 export function recognizeElementByConstructor({constructor}) {
-  return elementsReversedRegistry.has(constructor) && constructor;
+  return elementsRegistry.has(constructor) && constructor;
 }
 
 export function setup(element) {


### PR DESCRIPTION
This PR fixes the following mistakes:
- When the new built-in element is created, it has the `UNDEFINED` tag name.
- `whenDefined` method of the `customElements` instance does not follow the specification: it does not properly wait until the element is defined which could break the correct code.
